### PR TITLE
ci: Enable automatic tests execution via Github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  # Concurrency group that uses the workflow name and PR number if available
+  # or commit SHA as a fallback. If a new build is triggered under that
+  # concurrency group while a previous build is running it will be canceled.
+  # Repeated pushes to a PR will cancel all previous builds, while multiple
+  # merges to master will not cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.11']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install poetry
+        run: make poetry-download
+
+      - name: Set up cache
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('poetry.lock') }}
+
+      - name: Install dependencies
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry install
+
+      - name: Run tests
+        run: |
+          make test
+
+      - name: Archive Coverage Artifacts
+        uses: actions/upload-artifact@v4
+        # also upload in case of test failure, this does not affect the workflow end status
+        if: always()
+        with:
+          name: coverage-html-report-${{ matrix.python-version }}
+          path: htmlcov
+          retention-days: 5

--- a/Makefile
+++ b/Makefile
@@ -1,101 +1,67 @@
 #* Variables
-SHELL := /usr/bin/env bash
-PYTHON := python
-PYTHONPATH := `pwd`
+SHELL := /usr/bin/env bash -o pipefail -o errexit
 
 #* Installation
-.PHONY: install
 install:
 	poetry lock -n --no-update && poetry export --without-hashes > requirements.txt
 	poetry install -n
 	-poetry run mypy --install-types --non-interactive ./
 
 #* Poetry
-.PHONY: poetry-download
 poetry-download:
-	curl -sSL https://install.python-poetry.org | $(PYTHON) -
+	curl -sSL https://install.python-poetry.org | python -
 
 #* Formatters
-.PHONY: codestyle
 codestyle:
 	poetry run pyupgrade --exit-zero-even-if-changed --py37-plus **/*.py
 	poetry run isort --settings-path pyproject.toml ./
 	poetry run black --config pyproject.toml ./
 
-.PHONY: formatting
 formatting: codestyle
 
 #* Linting
-.PHONY: test
 test:
-	PYTHONPATH=$(PYTHONPATH) poetry run pytest -c pyproject.toml --record-mode=once --cov-report=html --cov=hyperliquid tests/
+	poetry run pytest -c pyproject.toml tests/
 	poetry run coverage-badge -o assets/images/coverage.svg -f
 
-.PHONY: check-codestyle
 check-codestyle:
 	poetry run isort --diff --check-only --settings-path pyproject.toml ./
 	poetry run black --diff --check --config pyproject.toml ./
 	poetry run darglint --verbosity 2 hyperliquid tests
 
-.PHONY: check
 check:
 	poetry run mypy --config-file pyproject.toml ./
 
-.PHONY: check-safety
 check-safety:
 	poetry check
 	poetry run safety check --full-report
 	poetry run bandit -ll --recursive hyperliquid tests
 
-.PHONY: lint
 lint: test check-codestyle mypy check-safety
 
-.PHONY: update-dev-deps
 update-dev-deps:
 	poetry add -D bandit@latest darglint@latest "isort[colors]@latest" mypy@latest pre-commit@latest pydocstyle@latest pylint@latest pytest@latest pyupgrade@latest safety@latest coverage@latest coverage-badge@latest pytest-cov@latest
 	poetry add -D --allow-prereleases black@latest
 
-#* Docker
-# Example: make docker-build VERSION=latest
-# Example: make docker-build IMAGE=some_name VERSION=0.1.0
-.PHONY: docker-build
-docker-build:
-	@echo Building docker $(IMAGE):$(VERSION) ...
-	docker build \
-		-t $(IMAGE):$(VERSION) . \
-		-f ./docker/Dockerfile --no-cache
-
-# Example: make docker-remove VERSION=latest
-# Example: make docker-remove IMAGE=some_name VERSION=0.1.0
-.PHONY: docker-remove
-docker-remove:
-	@echo Removing docker $(IMAGE):$(VERSION) ...
-	docker rmi -f $(IMAGE):$(VERSION)
-
 #* Cleaning
-.PHONY: pycache-remove
 pycache-remove:
 	find . | grep -E "(__pycache__|\.pyc|\.pyo$$)" | xargs rm -rf
 
-.PHONY: dsstore-remove
 dsstore-remove:
 	find . | grep -E ".DS_Store" | xargs rm -rf
 
-.PHONY: mypycache-remove
 mypycache-remove:
 	find . | grep -E ".mypy_cache" | xargs rm -rf
 
-.PHONY: ipynbcheckpoints-remove
 ipynbcheckpoints-remove:
 	find . | grep -E ".ipynb_checkpoints" | xargs rm -rf
 
-.PHONY: pytestcache-remove
 pytestcache-remove:
 	find . | grep -E ".pytest_cache" | xargs rm -rf
 
-.PHONY: build-remove
 build-remove:
 	rm -rf build/
 
-.PHONY: cleanup
 cleanup: pycache-remove dsstore-remove mypycache-remove ipynbcheckpoints-remove pytestcache-remove
+
+.PHONY: all $(MAKECMDGOALS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,17 +138,14 @@ addopts = [
   "--tb=short",
   "--doctest-modules",
   "--doctest-continue-on-failure",
+  "--record-mode=once",
+  "--cov-report=html",
+  "--cov=hyperliquid"
 ]
 
 [tool.coverage.run]
-source = ["tests"]
-
-[coverage.paths]
-source = "hyperliquid-python-sdk"
-
-[coverage.run]
 branch = true
 
-[coverage.report]
-fail_under = 50
+[tool.coverage.report]
+fail_under = 35
 show_missing = true


### PR DESCRIPTION
This PR enables automatic tests execution via Github workflow and by that publicly prove for every PR and commit merged to master if the tests are passing. This makes PR reviews easier and also gives a good impression about project maturity when there is automated and passing tests execution.

The SDK was derived from [python-package-template](https://github.com/TezRomacH/python-package-template) which unfortunately was heavily outdated at time of usage (and the repo meanwhile got archived).

This PR:
* Adds a github workflows for tests execution for PRs and commits merged to master... including coverage html report upload that can be downloaded from the workflow summary page, see e.g. here 
* Moves all the pytest args to the config in pyproject.toml to have all the args in one place
* Fixes the coverage config in pyproject.toml: the coverage toml keys have to be prefixed with `tool`, the `source` specifier is not required / was wrong, setting the min coverage slightly lower than the current actual coverage (36.XX %) to get a green testing baseline to work against.
* Update the Makefile: 
  * cleanup: mark all targets as PHONY via one line instead of many lines
  * cleanup: remove unused docker targets (there is no Dockerfile in the repo)
  * reliability: Instruct the shell to fail on failing multiline commands so that errors are not masked by succeeding lines
  * Do not specify the `PYTHONPATH` variable as that is not required (and it is an anti-pattern that would tell that something regarding the python project / test setup is not properly done)

Modernising of the linting / codestyle / pre-commit / security check code + automation via workflow is subject of more PRs to keep this PR small and reviewable.